### PR TITLE
Remove swiftlint installation for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ osx_image: xcode7.3
 cache: cocoapods
 
 before_install:
-  - brew update
-  - brew install swiftlint
   - gem install cocoapods
   - pod repo update --silent
   - gem install xcpretty


### PR DESCRIPTION
Looks like travis already includes swiftlint in their OS environments (https://travis-ci.org/Karumi/MaxibonKataIOS/builds/158976740)