### PR TITLE
Remove pod to custom Swiftcheck version an use an official version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode9
 
 before_install:
   - pod repo update --silent

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ target 'MaxibonKataIOS' do
 
   target 'MaxibonKataIOSTests' do
     inherit! :search_paths
-    pod 'SwiftCheck', :git => 'https://github.com/fjfdeztoro/SwiftCheck.git', :branch => 'fix-compilation-issues-xcode9'
+    pod 'SwiftCheck', :git => 'https://github.com/typelift/SwiftCheck.git', :commit => 'df82fb889864945c64458f38846702af729b3ee4'
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
-  - SwiftCheck (0.8.0)
+  - SwiftCheck (0.8.1)
 
 DEPENDENCIES:
-  - SwiftCheck (from `https://github.com/fjfdeztoro/SwiftCheck.git`, branch `fix-compilation-issues-xcode9`)
+  - SwiftCheck (from `https://github.com/typelift/SwiftCheck.git`, commit `df82fb889864945c64458f38846702af729b3ee4`)
 
 EXTERNAL SOURCES:
   SwiftCheck:
-    :branch: fix-compilation-issues-xcode9
-    :git: https://github.com/fjfdeztoro/SwiftCheck.git
+    :commit: df82fb889864945c64458f38846702af729b3ee4
+    :git: https://github.com/typelift/SwiftCheck.git
 
 CHECKOUT OPTIONS:
   SwiftCheck:
-    :commit: 6285e6a542846144c3c49bd01fac4b696b28ce81
-    :git: https://github.com/fjfdeztoro/SwiftCheck.git
+    :commit: df82fb889864945c64458f38846702af729b3ee4
+    :git: https://github.com/typelift/SwiftCheck.git
 
 SPEC CHECKSUMS:
-  SwiftCheck: bb6e75408ca538f733b095a7196db6070ee1ed17
+  SwiftCheck: 6ab9c2382eda70eebcd3cca9ada74de19b2b4d0a
 
-PODFILE CHECKSUM: 72207557597aa93eacf3e98bb233013f50b1ae71
+PODFILE CHECKSUM: f6f9c268d276716345e4112d0b98c9c0f071630b
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
Instead of using:
```
pod 'SwiftCheck', :git => 'https://github.com/fjfdeztoro/SwiftCheck.git', :branch => 'fix-compilation-issues-xcode9'
```
We are back to using the official repo but using their latest tag: 
```
pod 'SwiftCheck', :git => 'https://github.com/typelift/SwiftCheck.git', :tag => '0.9.1'
```